### PR TITLE
NodeBB v0.5.0 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
 		"simple-recaptcha": "~0.0.3"
 	},
 	  "peerDependencies": {
-    		"nodebb-theme-vanilla": "~0.0.137"
+    		"nodebb-theme-vanilla": ">0.0.137"
   	}
 }


### PR DESCRIPTION
Seems npm complains because it wants vanilla 0.0.x to be installed, whereas on the latest dev builds, we  are on v0.1.x.

Perhaps update the peerDep to ">0.0.137"?
