### PR TITLE
linting and adding compatibility hash

### DIFF
--- a/library.js
+++ b/library.js
@@ -1,4 +1,4 @@
-var	Akismet = require('akismet'),
+var Akismet = require('akismet'),
     Honeypot = require('project-honeypot'),
     simpleRecaptcha = require('simple-recaptcha'),
     pluginData = require('./plugin.json'),

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
 		"project-honeypot": "~0.0.0",
 		"simple-recaptcha": "~0.0.3"
 	},
-	  "peerDependencies": {
-    		"nodebb-theme-vanilla": ">=0.0.137"
-  	}
+	"peerDependencies": {
+		"nodebb-theme-vanilla": ">=0.0.137"
+	},
+	"nbbpm": {
+		"compatibility": "^0.6.0"
+	}
 }

--- a/plugin.json
+++ b/plugin.json
@@ -19,6 +19,5 @@
         {"hook": "filter:topic.post", "method": "checkReply", "priority": 5},
         {"hook": "filter:topic.reply", "method": "checkReply", "priority": 5}
     ],
-    "compatibility": "~0.5.0",
     "faIcon": "fa-shield"
 }


### PR DESCRIPTION
You should also create a branch based off of f874f418ae74f9b71e88d8771aa75129dcca2fee, and apply this commit to it as well, except change it to read `^0.5.0` instead.

Then publish that branch to npm as v0.2.52
