### PR TITLE
Allow reputable users on your forum to submit a post as spam to akismet

### DIFF
--- a/library.js
+++ b/library.js
@@ -6,6 +6,9 @@ var Akismet = require('akismet'),
     nconf = module.parent.require('nconf'),
     async = module.parent.require('async'),
     Meta = module.parent.require('./meta'),
+    user = module.parent.require('./user'),
+    topics = module.parent.require('./topics'),
+    db = module.parent.require('./database'),
     akismet, honeypot, recaptchaArgs, pluginSettings,
     Plugin = {};
 
@@ -156,6 +159,33 @@ Plugin.checkRegister = function(data, callback) {
     ], function(err, results) {
         callback(err, data);
     });
+};
+
+Plugin.onPostFlagged = function(flagged) {
+    if (akismet) {
+        async.parallel({
+            comment_author: function(next) {
+                user.getUserField(flagged.post.uid, 'username', next);
+            },
+            permalink: function(next) {
+                topics.getTopicField(flagged.post.tid, 'slug', next);
+            },
+            ip: function(next) {
+                db.getSortedSetRevRange('uid:' + flagged.post.uid + ':ip', 0, 1, next);
+            }
+        }, function(err, data) {
+            var submitted = { 
+                user_ip: data.ip ? data.ip[0] : '', 
+                permalink: nconf.get('url') + 'topic/' + data.permalink,
+                comment_author: data.comment_author,
+                comment_content: flagged.post.content
+            };
+
+            akismet.submitSpam(submitted, function(err) {
+                console.log('Spam reported to Akismet.', submitted);
+            });
+        });
+    }
 };
 
 Plugin._honeypotCheck = function(req, res, userData, next) {

--- a/library.js
+++ b/library.js
@@ -162,7 +162,7 @@ Plugin.checkRegister = function(data, callback) {
 };
 
 Plugin.onPostFlagged = function(flagged) {
-    if (akismet) {
+    if (akismet && pluginSettings.akismetFlagReporting && parseInt(flagged.flaggingUser.reputation, 10) >= parseInt(pluginSettings.akismetFlagReporting, 10)) {
         async.parallel({
             comment_author: function(next) {
                 user.getUserField(flagged.post.uid, 'username', next);

--- a/plugin.json
+++ b/plugin.json
@@ -17,7 +17,8 @@
         {"hook": "filter:register.build", "method": "addCaptcha", "priority": 5},
         {"hook": "filter:register.check", "method": "checkRegister", "priority": 5},
         {"hook": "filter:topic.post", "method": "checkReply", "priority": 5},
-        {"hook": "filter:topic.reply", "method": "checkReply", "priority": 5}
+        {"hook": "filter:topic.reply", "method": "checkReply", "priority": 5},
+        {"hook": "action:post.flag", "method": "onPostFlagged", "priority": 5}
     ],
     "faIcon": "fa-shield"
 }

--- a/templates/admin/plugins/spam-be-gone.tpl
+++ b/templates/admin/plugins/spam-be-gone.tpl
@@ -43,6 +43,11 @@
                     </div>
                 </div>
                 <p class="help-block">Keep your private key private</p>
+
+                <div class="form-group">
+					<label for="akismetFlagReporting">Allow users with minimum reputation of X to submit posts to Akismet as spam via flagging (leave blank to disable)</label>
+					<input placeholder="5" type="text" class="form-control" id="akismetFlagReporting" name="akismetFlagReporting" />
+				</div>
 			</div>
 		</div>
         <hr />


### PR DESCRIPTION
If content escapes akismet spam filter and gets posted, users with X reputation (settable in ACP) are able to submit this post as spam to akismet via the "flag post" button