### PR TITLE
fix parent require method using absolute path with  nbbRequire

### DIFF
--- a/lib/nbbRequire.js
+++ b/lib/nbbRequire.js
@@ -1,0 +1,6 @@
+var path = require('path');
+var nconf = require.main.require('nconf');
+
+module.exports = modulePath => {
+	return require(path.join(nconf.get('base_dir'), modulePath));
+};

--- a/library.js
+++ b/library.js
@@ -3,14 +3,18 @@
 
 var Honeypot = require('project-honeypot');
 var simpleRecaptcha = require('simple-recaptcha-new');
+
 var pluginData = require('./plugin.json');
+var nbbRequire = require('./lib/nbbRequire');
+
+var Meta = nbbRequire('./src/meta');
+var user = nbbRequire('./src/user');
+var topics = nbbRequire('./src/topics');
+var db = nbbRequire('./src/database');
+
 var winston = require.main.require('winston');
 var nconf = require.main.require('nconf');
 var async = require.main.require('async');
-var Meta = require.main.require('./src/meta');
-var user = require.main.require('./src/user');
-var topics = require.main.require('./src/topics');
-var db = require.main.require('./src/database');
 
 var akismet;
 var honeypot;


### PR DESCRIPTION
This fix the warning in NodeBB 1.10.* "warn: [plugins/require] please update module.parent.require" for linked npm package (development mode) and for npm registry imported package (classic install)