### PR TITLE
fix: url-encode the reCAPTCHA siteverify body

### DIFF
--- a/library.js
+++ b/library.js
@@ -453,14 +453,18 @@ Plugin._honeypotCheck = async function (req, userData) {
 
 Plugin._recaptchaCheck = async function (req) {
 	if (recaptchaArgs && req && req.ip && req.body) {
-		const postData = `secret=${pluginSettings.recaptchaPrivateKey}&response=${req.body['g-recaptcha-response']}&remoteip=${req.ip}`;
+		const postData = new URLSearchParams({
+			secret: pluginSettings.recaptchaPrivateKey,
+			response: String(req.body['g-recaptcha-response'] || ''),
+			remoteip: req.ip,
+		}).toString();
 		const options = {
 			hostname: 'www.recaptcha.net',
 			path: '/recaptcha/api/siteverify',
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
-				'Content-Length': postData.length,
+				'Content-Length': Buffer.byteLength(postData),
 			},
 		};
 
@@ -473,7 +477,14 @@ Plugin._recaptchaCheck = async function (req) {
 				});
 
 				res.on('end', () => {
-					const response = JSON.parse(responseData);
+					let response;
+					try {
+						response = JSON.parse(responseData);
+					} catch (err) {
+						// a throw here would be uncaught, this promise has already been handed off
+						reject(new Error('[[spam-be-gone:captcha-not-verified]]'));
+						return;
+					}
 
 					if (response.success === true) {
 						resolve();


### PR DESCRIPTION
`Plugin._recaptchaCheck` builds the siteverify form body by string interpolation:

```js
const postData = `secret=${pluginSettings.recaptchaPrivateKey}&response=${req.body['g-recaptcha-response']}&remoteip=${req.ip}`;
```

`g-recaptcha-response` comes straight from the request body and is never encoded, so a value containing `&` or `=` injects additional parameters into the request. `g-recaptcha-response=x&remoteip=1.2.3.4` produces:

```
secret=KEY&response=x&remoteip=1.2.3.4&remoteip=<real ip>
```

Google ignores duplicate/unknown parameters on `siteverify` today, so I don't think this is exploitable as it stands — the practical effect is that the `remoteip` the plugin reports can be made ambiguous. It matters if the request ever grows a parameter whose value is trusted, and the body shouldn't be attacker-shapeable regardless.

Changes:

- build the body with `URLSearchParams`, which encodes every value for `application/x-www-form-urlencoded` — the body now always has exactly the three intended parameters
- `Content-Length: Buffer.byteLength(postData)` instead of `postData.length`, which was wrong for any multi-byte content (moot once everything is percent-encoded, but correct either way)
- guard the `JSON.parse` of the response

The `JSON.parse` is a separate bug in the same function: it runs inside the `res.on('end')` handler, which fires after the Promise executor has already returned. A non-JSON response — an HTML error page from recaptcha.net, a truncated body — throws past the promise and becomes an uncaught exception rather than a rejected captcha check. It now rejects with `[[spam-be-gone:captcha-not-verified]]`, same as a `success: false` response.