### PR TITLE
Fix: missing return in reportFromQueue dereferences null

### DIFF
--- a/library.js
+++ b/library.js
@@ -164,7 +164,7 @@ Plugin.report = async function (req, res, next) {
 Plugin.reportFromQueue = async (req, res) => {
 	const data = await db.getObject(`registration:queue:name:${req.params.username}`);
 	if (!data) {
-		res.status(400).json({ message: '[[error:no-user]]' });
+		return res.status(400).json({ message: '[[error:no-user]]' });
 	}
 	const submitData = {
 		ip: data.ip,


### PR DESCRIPTION
In `Plugin.reportFromQueue`, when no registration-queue entry matches the username, the 400 response is sent without a `return`, so execution falls through and reads `data.ip` on `null`. That throw happens outside the `try` block, and the route is registered as a bare `router.post` with an async handler, so the rejection is unhandled — on top of the attempted double response.

This adds the missing `return`.